### PR TITLE
Use `tmt` based executor

### DIFF
--- a/installability.fmf
+++ b/installability.fmf
@@ -65,4 +65,4 @@ prepare:
         fi
 
 execute:
-    how: shell
+    how: shell.tmt


### PR DESCRIPTION
This will soon be the default and actually works with mil

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>