### PR TITLE
Add profiles for CentOS Stream 8 and 9

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,6 +34,14 @@
         "f42": {
             "profile_name": "fedora-42",
             "compose": "Fedora-Rawhide"
+        },
+        "epel8": {
+            "profile_name": "centos-stream-8",
+            "compose": "CentOS-Stream-8"
+        },
+        "epel9": {
+            "profile_name": "centos-stream-9",
+            "compose": "CentOS-Stream-9"
         }
     }
 }


### PR DESCRIPTION
Note that I am working on a patch to mini-tps, as the profile for the CS8 is not there.

Related to:
https://github.com/fedora-ci/mini-tps/pull/27
https://pagure.io/fedora-ci/general/issue/439