### PR TITLE
Run all checks together and upload custom result viewer

### DIFF
--- a/installability.fmf
+++ b/installability.fmf
@@ -11,22 +11,10 @@ discover:
       framework: shell
       test: bash prepare.sh
       duration: 30m
-    - name: install
+    - name: installability
       framework: shell
-      test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --test=install --repo=brew-$TASK_ID
-      duration: 240m
-    - name: update
-      framework: shell
-      test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --test=update --repo=brew-$TASK_ID
-      duration: 240m
-    - name: downgrade
-      framework: shell
-      test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --test=downgrade --repo=brew-$TASK_ID
-      duration: 240m
-    - name: remove
-      framework: shell
-      test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --test=remove --repo=brew-$TASK_ID
-      duration: 240m
+      test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --repo=brew-$TASK_ID
+      duration: 960m
 
 execute:
     how: tmt

--- a/installability_runner.sh
+++ b/installability_runner.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+get_result () {
+    local result
+    case $1 in
+        0) result="pass" ;;
+        1) result="fail" ;;
+        *) result="error" ;;
+    esac
+    echo "$result"
+}
+
+highrc=0
+. /var/tmp/mini-tps/env
+for method in "install" "update" "downgrade" "remove"; do
+    mtps-run-tests $@ --test="$method";
+    thisrc=$?
+    thisres="$(get_result $thisrc)"
+    echo "$method result: $thisres (status code: $thisrc)"
+    if [ "$thisrc" -gt "$highrc" ]; then
+        highrc="$thisrc"
+    fi
+done
+tmtresult="$(get_result $highrc)"
+if [ -n "$TMT_TEST_DATA" ]; then
+    # generate the result JSON
+    /usr/libexec/mini-tps/viewer/generate-result-json ./mtps-logs > "$TMT_TEST_DATA/result.json"
+    # copy the viewer HTML
+    cp /usr/share/mini-tps/viewer/viewer.html "$TMT_TEST_DATA/viewer.html"
+
+    cat <<FOE > "$TMT_TEST_DATA/results.yaml"
+- name: /installability
+  result: $tmtresult
+  log:
+    - viewer.html
+    - ../output.txt
+    - result.json
+FOE
+    echo "running in TMT, wrote $TMT_TEST_DATA/results.yaml"
+fi
+echo "mtps-run-tests overall result: $tmtresult (status code: $highrc)"
+exit $highrc

--- a/prepare.sh
+++ b/prepare.sh
@@ -18,12 +18,7 @@ export BREWHUB=https://koji.fedoraproject.org/kojihub
 export BREWROOT=https://kojipkgs.fedoraproject.org
 EOF
 
-cat << EOF > /usr/local/libexec/mini-tps/installability_runner.sh
-#!/bin/bash
-set -e
-. /var/tmp/mini-tps/env
-mtps-run-tests \$@
-EOF
+cp installability_runner.sh /usr/local/libexec/mini-tps/installability_runner.sh
 chmod +x /usr/local/libexec/mini-tps/installability_runner.sh
 
 . /var/tmp/mini-tps/env


### PR DESCRIPTION
Inspired by https://github.com/fedora-ci/rpminspect-runner/pull/80 this does much the same for installability. Instead of running four separate tests, run all four checks in a single test, then (using the stuff from
https://github.com/fedora-ci/mini-tps/pull/18 ) generate the result JSON, put it and the viewer HTML into the test data dir, and write a custom results.yaml pointing to it. This should result in the viewer being easily accessible from the TF results, giving packagers a much nicer view on the results.