### PR TITLE
Specify result 'custom' in installability.fmf to activate viewer

### DIFF
--- a/installability.fmf
+++ b/installability.fmf
@@ -15,6 +15,7 @@ discover:
       framework: shell
       test: /usr/local/libexec/mini-tps/installability_runner.sh --critical --skiplangpack --selinux=1 --repo=brew-$TASK_ID
       duration: 960m
+      result: custom
 
 execute:
     how: tmt

--- a/installability_runner.sh
+++ b/installability_runner.sh
@@ -32,8 +32,8 @@ if [ -n "$TMT_TEST_DATA" ]; then
 - name: /installability
   result: $tmtresult
   log:
-    - viewer.html
     - ../output.txt
+    - viewer.html
     - result.json
 FOE
     echo "running in TMT, wrote $TMT_TEST_DATA/results.yaml"


### PR DESCRIPTION
After merging #25, the custom viewer was still not showing by default in the web UI for installability results. We think this should solve it - the test definition in installability.fmf needs to tell the system to expect a custom result.