### PR TITLE
Add profile for EPEL10

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,6 +40,10 @@
     "epel9": {
       "profile_name": "centos-stream-9",
       "compose": "CentOS-Stream-9"
+    },
+    "epel10": {
+      "profile_name": "centos-stream-10",
+      "compose": "CentOS-Stream-10"
     }
   }
 }


### PR DESCRIPTION
This would help check installability on epel10 branches.
JIC I already sent a PR to add centos-stream-10 as a valid target on mini-tps https://github.com/fedora-ci/mini-tps/pull/70