### PR TITLE
Rename prepare to _prepare

### DIFF
--- a/installability.fmf
+++ b/installability.fmf
@@ -7,7 +7,7 @@ provision:
 discover:
     how: shell
     tests:
-    - name: prepare
+    - name: _prepare
       framework: shell
       test: bash prepare.sh
       duration: 30m


### PR DESCRIPTION
If tmt tries to run tests in the alphabetical order, _prepare should go first.