### PR TITLE
Download both epel and epel-next release packages on centos targets

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -55,7 +55,12 @@ if [[ "$PROFILE_NAME" == centos-stream-* ]]; then
 
     CENTOS_STREAM_RELEASE=$(sed 's/centos-stream-//' <<< "$PROFILE_NAME")
     EPEL_RELEASE_PACKAGE_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-$CENTOS_STREAM_RELEASE.noarch.rpm"
-    rpm -q epel-release && yum -y reinstall "$EPEL_RELEASE_PACKAGE_URL" || yum -y install "$EPEL_RELEASE_PACKAGE_URL"
+    if [[ "$CENTOS_STREAM_RELEASE" == "9" ]]; then
+        EPEL_NEXT_RELEASE_PACKAGE_URL="https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-$CENTOS_STREAM_RELEASE.noarch.rpm"
+        rpm -q epel-release && yum -y reinstall "$EPEL_RELEASE_PACKAGE_URL" "$EPEL_NEXT_RELEASE_PACKAGE_URL" || yum -y install "$EPEL_RELEASE_PACKAGE_URL" "$EPEL_NEXT_RELEASE_PACKAGE_URL"
+    else
+        rpm -q epel-release && yum -y reinstall "$EPEL_RELEASE_PACKAGE_URL" || yum -y install "$EPEL_RELEASE_PACKAGE_URL"
+    fi
 
     yum config-manager --enable crb
     yum config-manager --enable epel


### PR DESCRIPTION
Yesterday someone raised a problem with the installability-CI on the EPEL Matrix channel, where their PRs wouldn't be able to pass.

https://artifacts.dev.testing-farm.io/f785c048-458b-4fd1-a37b-39894af18ce5/

Looking into this, I noticed that the current preparation scripts install the epel release package from the release url, but as it requires the epel-next package, it's version conflicts with the one already distributed with the image.

I added a fix for the EPEL9 case, since it's the only active version that uses the epel-next repo. EPEL8 was retired because of Centos8 EOL and EPEL10 uses a different model without the epel-next repo.