### PR TITLE
Fix dependency install for F40

### DIFF
--- a/installability.fmf
+++ b/installability.fmf
@@ -15,9 +15,9 @@ prepare:
   - name: Install mini-tps dependencies
     how: install
     package:
-      - getopt
-      - awk
-      - ps
+      - /usr/bin/getopt
+      - /usr/bin/awk
+      - /usr/bin/ps
 
 discover:
   how: shell


### PR DESCRIPTION
Sorry, I broke F40 because it cannot resolve the executables directly, see: https://artifacts.dev.testing-farm.io/efa90eb5-74e1-4c1d-8802-1caae9851ffa/

Coincidentally I realized that if `$TASK_ID` is not provided `SKIP_TEST` is not actually populated. But haven't thought of if it makes sense to revesit it.