### PR TITLE
Copy the logs to the actual log directory

### DIFF
--- a/installability_runner.sh
+++ b/installability_runner.sh
@@ -34,6 +34,10 @@ else
           highrc="$thisrc"
       fi
   done
+  # Copy the mtps-logs to the actual log directory
+  if [[ -d mtps-logs ]]; then
+    cp mtps-logs/* ${LOGS_DIR}/
+  fi
   tmtresult="$(get_result $highrc)"
 fi
 


### PR DESCRIPTION
It seems that `mtps-run-tests` always writes to `mtps-logs`, which was out-of-sync with the `LOGS_DIR` variable that was provided. Fixes https://pagure.io/releng/issue/12658