### PR TITLE
Do not run downgrade test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ retry (10) {
 
 def pipelineMetadata = [
     pipelineName: 'installability',
-    pipelineDescription: 'Try to install, upgrade, downgrade and remove RPM packages.',
+    pipelineDescription: 'Try to install, upgrade and remove RPM packages.',
     testCategory: 'functional',
     testType: 'installability',
     maintainer: 'Fedora CI',

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the definition of the Installability CI pipeline.
 
-This pipeline tries to install, update, downgrade and remove RPM packages and publishes results via [CI Messages](https://pagure.io/fedora-ci/messages).
+This pipeline tries to install, update and remove RPM packages and publishes results via [CI Messages](https://pagure.io/fedora-ci/messages).
 
 ## Test definition
 

--- a/installability_runner.sh
+++ b/installability_runner.sh
@@ -25,7 +25,7 @@ if [[ -f ${TMT_PLAN_DATA}/SKIP_TEST ]]; then
   tmtresult="skip"
 else
   highrc=0
-  for method in "install" "update" "downgrade" "remove"; do
+  for method in "install" "update" "remove"; do
       mtps-run-tests "$@" --test="$method";
       thisrc=$?
       thisres="$(get_result $thisrc)"


### PR DESCRIPTION
Downgrade has never been required to work on Fedora. One particularly unfortunate consequence of running it is that updates which fix a package with broken dependencies fail the downgrade test, precisely because the previous build was broken and cannot be downgraded to.